### PR TITLE
Change little in algorithm

### DIFF
--- a/p2.cc
+++ b/p2.cc
@@ -84,8 +84,8 @@ void p2_t::add_quantile( double quant )
 	double *markers = allocate_markers( 3 );
 
 	/* Add in appropriate dn markers */
-	markers[0] = quant;
-	markers[1] = quant/2.0;
+	markers[0] = quant/2.0;
+	markers[1] = quant;
 	markers[2] = (1.0+quant)/2.0;
 
 	update_markers( );


### PR DESCRIPTION
I think it should be quantile/2.0 first and then quantile in function add_quantile. In addition, in the result function you get dn[(marker_count - 1) / 2], so it must calculate to the position of quantile but in this code is quantile/2.0. Furthermore, this PR following the P^2 algorithm as documented in "The P-Square Algorithm for Dynamic Calculation of Percentiles and Histograms without Storing Observations," Communications of the ACM, October 1985 by R. Jain and I. Chlamtac.